### PR TITLE
Move error strings to constants for easier error overview/maintenance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ A query bus to fetch all the things.
 4. [Iterator Handlers](#Iterator-Handlers)
 5. [Iterator Result](#Iterator-Result)
 6. [Error Handlers](#Error-Handlers)
+   1. [Available Errors](#Available-Errors)
 6. [Cache Adapters](#Cache-Adapters)
 7. [The Bus](#The-Bus)  
    1. [Tweaking Performance](#Tweaking-Performance)  
    2. [Shutting Down](#Shutting-Down)  
+   3. [Available Errors](#Available-Errors)
 8. [Benchmarks](#Benchmarks)
 9. [Examples](#Examples)
 
@@ -85,6 +87,35 @@ type ErrorHandler interface {
 }
 ```
 Any time an error occurs within the bus, it will be passed on to the error handlers. This strategy can be used for decoupled error handling.
+
+#### Available Errors
+Below is a list of errors that can occur.  
+
+```go
+// query.InvalidQueryError  
+// query.QueryBusNotInitializedError
+// query.QueryBusIsShuttingDownError
+// query.ErrorNoQueryHandlersFound
+// query.ErrorQueryTimedOut
+
+type errorHandler struct {}
+func (e errorHandler) Handle(qry Query, err error) {
+    switch(err.(type)) {
+        case query.InvalidQueryError:
+            // do something
+        case query.QueryBusNotInitializedError:
+            // do something
+        case query.QueryBusIsShuttingDownError:
+            // do something
+        case query.ErrorQueryTimedOut, query.ErrorNoQueryHandlersFound:
+            // do something
+        default:
+            // do something
+    }
+}
+bus.ErrorHandlers(errorHandler)
+
+```
 
 ### Cache Adapters
 Cache adapters are any type that implements the _CacheAdapter_ interface. Cache adapters are optional (but advised) and provided to the bus using the ```bus.CacheAdapters``` function.  

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,51 @@
+package query
+
+import "fmt"
+
+const (
+	InvalidQueryError           = ErrorInvalidQuery("query: invalid query")
+	QueryBusNotInitializedError = ErrorQueryBusNotInitialized("query: the query bus is not initialized")
+	QueryBusIsShuttingDownError = ErrorQueryBusIsShuttingDown("query: the query bus is shutting down")
+)
+
+type ErrorInvalidQuery string
+
+func (e ErrorInvalidQuery) Error() string {
+	return string(e)
+}
+
+type ErrorQueryBusNotInitialized string
+
+func (e ErrorQueryBusNotInitialized) Error() string {
+	return string(e)
+}
+
+type ErrorQueryBusIsShuttingDown string
+
+func (e ErrorQueryBusIsShuttingDown) Error() string {
+	return string(e)
+}
+
+type ErrorNoQueryHandlersFound struct {
+	query Query
+}
+
+func (e ErrorNoQueryHandlersFound) Error() string {
+	return fmt.Sprintf("query: no handlers were found for the query %T", e.query)
+}
+
+func NewErrorNoQueryHandlersFound(query Query) ErrorNoQueryHandlersFound {
+	return ErrorNoQueryHandlersFound{query: query}
+}
+
+type ErrorQueryTimedOut struct {
+	query Query
+}
+
+func (e ErrorQueryTimedOut) Error() string {
+	return fmt.Sprintf("query: the query %T timed out due to lack of result listeners. This may happen if a query was issued but the \"Iterate\" function of the result was not handled", e.query)
+}
+
+func NewErrorQueryTimedOut(query Query) ErrorQueryTimedOut {
+	return ErrorQueryTimedOut{query: query}
+}


### PR DESCRIPTION
```go
type errorHandler struct {}
func (e errorHandler) Handle(qry Query, err error) {
    switch(err.(type)) {
        case query.InvalidQueryError:
            // do something
        case query.QueryBusNotInitializedError:
            // do something
        case query.QueryBusIsShuttingDownError:
            // do something
        case query.ErrorQueryTimedOut, query.ErrorNoQueryHandlersFound:
            // do something
        default:
            // do something
    }
}
bus.ErrorHandlers(errorHandler)
```